### PR TITLE
feat: 로그인 화면 구현 완료

### DIFF
--- a/client/src/assets/css/init.css
+++ b/client/src/assets/css/init.css
@@ -41,7 +41,7 @@ input,
 select {
   margin: 0;
 }
-html {
+* {
   box-sizing: border-box;
 }
 *,

--- a/client/src/assets/css/typography.css
+++ b/client/src/assets/css/typography.css
@@ -5,14 +5,14 @@
 }
 @font-face {
   font-family: bd;
-  src: url('../fonts/MediumLL-Bold.otf');
   src: url('../fonts/SpoqaHanSansNeo-Bold.woff');
+  src: url('../fonts/MediumLL-Bold.otf');
   font-weight: 700;
 }
 @font-face {
   font-family: nm;
-  src: url('../fonts/MediumLL-Book.otf');
   src: url('../fonts/SpoqaHanSansNeo-Regular.woff');
+  src: url('../fonts/MediumLL-Book.otf');
   font-weight: 400;
 }
 body {
@@ -23,15 +23,18 @@ h1 {
   font-family: 'h1', sans-serif;
   font-style: oblique;
   font-size: 2.5rem;
-  margin: 0 1.5rem 1rem 1rem;
+  margin: 0 0 1rem 0;
 }
 h2 {
   font-family: 'nm', sans-serif;
   font-size: 1.5rem;
-  margin: 0 1.5rem 1rem 1rem;
+  margin: 0 1rem 0 0;
 }
 h3 {
   font-family: 'bd', sans-serif;
   font-size: 1.25rem;
-  margin: 0 1.5rem 1rem 0;
+  margin: 0 0 1rem 0;
+}
+p {
+  margin: 0 0.5rem 0 0;
 }

--- a/client/src/core/api/axiosConfig.js
+++ b/client/src/core/api/axiosConfig.js
@@ -54,9 +54,9 @@ const call = async (uri, method = 'get', data, authType = 'normal') => {
     if (method === 'put') result = await instance.put(URI, data);
     if (method === 'delete') result = await instance.delete(URI);
     //promise 객체
-    return result.data;
+    return result;
   } catch (err) {
-    return err.response.status;
+    return err;
   }
 };
 

--- a/client/src/core/components/About/AboutBtn.vue
+++ b/client/src/core/components/About/AboutBtn.vue
@@ -37,19 +37,18 @@ export default {
 }
 
 #aboutBtn {
-  border-radius: 24px;
+  border-radius: 3rem;
   border: 1px solid var(--light-color-darkgrey);
   color: var(--light-color-darkgrey);
   background: white;
   cursor: pointer;
-  height: 3rem;
+  height: 2.75rem;
   width: 3rem;
   font-size: 1.25rem;
 }
 
 #aboutBtn:hover {
-  width: 2.75rem;
-  height: 2.75rem;
+  opacity: 0.7;
   font-size: 1rem;
 }
 

--- a/client/src/core/components/About/AboutContent.vue
+++ b/client/src/core/components/About/AboutContent.vue
@@ -3,8 +3,8 @@
   <!--class attribute의 show를 바인딩해 사용합니다.-->
   <article id="about_content_container" :class="{ show: show }">
     <div id="about_content_content">
-      <h1>PULSAR</h1>
-      <p>TEAM 최종병기 망치</p>
+      <h1>CREDITS</h1>
+      <p>민병기, 유승윤</p>
     </div>
   </article>
 </template>

--- a/client/src/module/common/RoundButton.vue
+++ b/client/src/module/common/RoundButton.vue
@@ -9,25 +9,6 @@
   </button>
 </template>
 
-<style scoped>
-@import url('../../assets/css/init.css');
-@import url('../../assets/css/root.css');
-@import url('../../assets/css/typography.css');
-
-button {
-  cursor: pointer;
-  background-color: var(--color);
-  padding: 0.5rem 0.75rem 0.5rem 0.75rem;
-  border: var(--border);
-  border-radius: 1.5rem;
-  color: var(--text);
-}
-
-button:hover {
-  opacity: 0.7;
-}
-</style>
-
 <script>
 export default {
   name: 'RoundButton',
@@ -48,7 +29,7 @@ export default {
       }
       if (this.theme === 'highlight') {
         return {
-          '--color': '#eca23c',
+          '--color': '#ff8048',
           '--border': 'none',
           '--text': 'white',
         };
@@ -62,3 +43,22 @@ export default {
   },
 };
 </script>
+
+<style scoped>
+@import url('../../assets/css/init.css');
+@import url('../../assets/css/root.css');
+@import url('../../assets/css/typography.css');
+
+button {
+  cursor: pointer;
+  background-color: var(--color);
+  padding: 0.5rem 0.75rem 0.5rem 0.75rem;
+  border: var(--border);
+  border-radius: 1.5rem;
+  color: var(--text);
+}
+
+button:hover {
+  opacity: 0.7;
+}
+</style>

--- a/client/src/module/common/SquareButton.vue
+++ b/client/src/module/common/SquareButton.vue
@@ -1,0 +1,74 @@
+<template>
+  <div class="square_button_container">
+    <button
+      type="button"
+      class="btn"
+      :style="styles"
+      @click="handleClick"
+    >
+      {{ value ? value : 'example' }}
+    </button>
+  </div>
+</template>
+
+<style scoped>
+@import url('../../assets/css/init.css');
+@import url('../../assets/css/root.css');
+@import url('../../assets/css/typography.css');
+
+.square_button_container {
+  width: 100%;
+}
+
+button {
+  cursor: pointer;
+  background-color: var(--color);
+  padding: 0.75rem 1.25rem 0.75rem 1.25rem;
+  border: var(--border);
+  border-radius: 8px;
+  color: var(--text);
+  width: calc(100% - 3rem);
+  margin-bottom: 1rem;
+  font-size: 1rem;
+  font-family: 'bd', sans-serif;
+}
+
+button:hover {
+  opacity: 0.7;
+}
+</style>
+
+<script>
+export default {
+  name: 'SquareButton',
+  props: { theme: String, value: String },
+  methods: {
+    handleClick(event) {
+      this.$emit('handle-click');
+    },
+  },
+  computed: {
+    styles() {
+      if (this.theme === 'black') {
+        return {
+          '--color': '#333333',
+          '--border': '1px solid #333333',
+          '--text': 'white',
+        };
+      }
+      if (this.theme === 'highlight') {
+        return {
+          '--color': '#ff8048',
+          '--border': '1px solid #ff8048',
+          '--text': 'white',
+        };
+      } else
+        return {
+          '--color': 'white',
+          '--border': '1px solid #333333',
+          '--text': '#333333',
+        };
+    },
+  },
+};
+</script>

--- a/client/src/module/common/TextInput.vue
+++ b/client/src/module/common/TextInput.vue
@@ -1,62 +1,69 @@
 <template>
-  <div>
-    <label :html-for="inputName">{{ inputName }}</label>
-    <input
-      :id="inputName"
-      type="text"
-      class="btn"
-      :style="styles"
-      :placeholder="placeholder"
-      @input="$emit('handle-change', $event)"
-      v-model="value"
-    />
+  <div class="text_input_container" :style="styles">
+    <div class="text_input_container_label">
+      <label :html-for="inputName" />
+    </div>
+    <div class="text_input_container_input">
+      <input
+        :id="inputName"
+        :type="type"
+        :placeholder="placeholder"
+        :value="value"
+        @change="$emit('input', $event.target.value)"
+      />
+      <p class="caption">{{ caption }}</p>
+    </div>
   </div>
 </template>
-
-<style scoped>
-@import url('../../assets/css/init.css');
-@import url('../../assets/css/root.css');
-@import url('../../assets/css/typography.css');
-
-Input[type='text'] {
-  padding: 0.5rem 0.75rem 0.5rem 0.75rem;
-  width: var(--width);
-  border: 1px solid var(--light-color-black);
-  border-radius: 6px;
-  outline: none;
-}
-
-Input::placeholder {
-  color: var(--light-color-grey);
-}
-</style>
 
 <script>
 export default {
   name: 'TextInput',
   props: {
-    placeholder: String,
     inputName: String,
-    callback: Function,
-    width: String,
-  },
-  methods: {
-    handleChange(event) {
-      const data = this.value;
-      this.$emit('handle-change', data);
-    },
-  },
-  data() {
-    return {
-      value: '',
-    };
+    type: String,
+    placeholder: String,
+    caption: String,
+    value: String,
+    margin: String,
   },
   computed: {
     styles() {
       return {
-        '--width': this.width,
+        '--margin': this.margin,
+        '--display': this.caption ? 'block' : 'none',
       };
     },
   },
 };
 </script>
+
+<style scoped>
+@import url('../../assets/css/init.css');
+@import url('../../assets/css/root.css');
+@import url('../../assets/css/typography.css');
+.text_input_container {
+  margin-bottom: var(--margin);
+}
+input[type='text'],
+input[type='email'],
+input[type='password'] {
+  padding: 0.75rem 1.25rem 0.75rem 1.25rem;
+  border: 1px solid var(--light-color-black);
+  border-radius: 6px;
+  outline: none;
+  font-size: 1rem;
+  width: calc(100% - 3rem);
+}
+
+input::placeholder {
+  color: var(--light-color-grey);
+}
+.caption {
+  color: var(--light-color-darkgrey);
+  text-align: right;
+  font-size: 0.85rem;
+  padding: 0.5rem 0 0.5rem 0;
+  display: var(--display);
+}
+</style>

--- a/client/src/module/landing/LandingView.vue
+++ b/client/src/module/landing/LandingView.vue
@@ -1,18 +1,16 @@
 <template>
   <div id="landing_wrapper">
+    <welcome-pulsar />
     <router-view />
   </div>
 </template>
 
-<style scoped>
-@import url('../../assets/css/init.css');
-@import url('../../assets/css/root.css');
-@import url('../../assets/css/typography.css');
-</style>
-
 <script>
+import WelcomePulsar from './components/WelcomePulsar.vue';
+
 export default {
-  name: '',
+  name: 'LandingView',
+  components: { WelcomePulsar },
   data() {
     return {};
   },
@@ -23,3 +21,15 @@ export default {
   },
 };
 </script>
+
+<style scoped>
+@import url('../../assets/css/init.css');
+@import url('../../assets/css/root.css');
+@import url('../../assets/css/typography.css');
+
+#landing_wrapper {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+</style>

--- a/client/src/module/landing/components/LoginContainer.vue
+++ b/client/src/module/landing/components/LoginContainer.vue
@@ -1,39 +1,39 @@
 <template>
-  <div id="Login_Container">
+  <div id="login_container">
     <login-content @login="login" />
   </div>
 </template>
-
-<style scoped>
-@import url('../../../assets/css/init.css');
-@import url('../../../assets/css/root.css');
-@import url('../../../assets/css/typography.css');
-</style>
 
 <script>
 import LoginContent from './LoginContent.vue';
 import { postMemberLogIn } from '../../../core/api/member';
 
 export default {
-  name: 'LogIn',
+  name: 'LoginContainer',
   components: { LoginContent },
-  data() {
-    return {
-      email: '',
-      password: '',
-    };
-  },
   methods: {
-    login() {
-      const data = {
-        email: this.email,
-        password: this.password,
-      };
-      postMemberLogIn(data).then((a) => {
-        //vuex store에 정보 저장
-        //redirect
-      });
+    login(email, password) {
+      const data = { email, password }; //데이터를 API 형식에 맞춰 서버로 보냅니다
+      postMemberLogIn(data)
+        .then((res) => {
+          //vuex store에 정보 저장
+          console.log(res.data);
+          console.log('로그인이 되었어요');
+          //기본 화면인 루틴으로 리다이렉트시킵니다.
+          this.$router.push('/routines');
+        })
+        .catch((err) => err.status);
     },
   },
 };
 </script>
+
+<style scoped>
+@import url('../../../assets/css/init.css');
+@import url('../../../assets/css/root.css');
+@import url('../../../assets/css/typography.css');
+
+#login_container {
+  height: 66vh;
+}
+</style>

--- a/client/src/module/landing/components/LoginContent.vue
+++ b/client/src/module/landing/components/LoginContent.vue
@@ -1,20 +1,32 @@
 <template>
-  <div id="Login_Container">
+  <div id="login_content">
+    <!-- 상위 컴포넌트에서 v-model은 하위 컴포넌트에서 emit해 바인딩할 수 있습니다.
+         v-model이 하위 컴포넌트에서의 emit + 그 하위 컴포넌트로 pass prop인 것을 이용한 것입니다. -->
+    <h2>로그인</h2>
+    <p class="login_content_caption">
+      서비스를 이용하려면 로그인해야 합니다.
+    </p>
     <text-input
-      :placeholder="'email'"
-      :width="'10rem'"
-      @handle-change="email = $event.target.value"
+      :input-name="'Email'"
+      :placeholder="'Email'"
+      :type="'email'"
+      :margin="'1rem'"
+      v-model="email"
     />
     <text-input
-      :placeholder="'password'"
-      :width="'10rem'"
-      @handle-change="password = $event.target.value"
+      :input-name="'Password'"
+      :placeholder="'Password'"
+      :type="'password'"
+      :margin="'1rem'"
+      :caption="'영문 소문자, 숫자, 특수문자 포함 8자리 이상'"
+      v-model="password"
     />
-    <round-button
-      :theme="'black'"
+    <square-button
+      :theme="'highlight'"
       :value="'LOGIN'"
-      @handle-click="$emit('login', email, password)"
+      @handle-click="handleClick"
     />
+    <square-button :theme="'white'" :value="'SIGN UP'" />
   </div>
 </template>
 
@@ -22,20 +34,37 @@
 @import url('../../../assets/css/init.css');
 @import url('../../../assets/css/root.css');
 @import url('../../../assets/css/typography.css');
+
+#login_content {
+  padding: 1.5rem;
+}
+.login_content_caption {
+  margin: 1rem 0 2rem 0;
+}
 </style>
 
 <script>
-import RoundButton from '../../common/RoundButton.vue';
+import SquareButton from '../../common/SquareButton.vue';
 import TextInput from '../../common/TextInput.vue';
 
 export default {
-  name: 'LogIn',
-  components: { TextInput, RoundButton },
+  name: 'LoginContent',
+  components: { TextInput, SquareButton },
   data() {
     return {
+      //각 커스텀 인풋 컴포넌트에서 받은 입력값을 v-model로 양방향 바인딩합니다.
       email: '',
       password: '',
     };
+  },
+  methods: {
+    handleClick() {
+      //로그인을 시도하기 위해 위쪽으로 로그인 이벤트와 값을 보내고,
+      //양방향 바인딩되어 있는 데이터 쪽의 값을 초기화해 인풋을 빈 값으로 만듭니다.
+      this.$emit('login', this.email, this.password);
+      this.email = '';
+      this.password = '';
+    },
   },
 };
 </script>

--- a/client/src/module/landing/components/WelcomePulsar.vue
+++ b/client/src/module/landing/components/WelcomePulsar.vue
@@ -1,0 +1,37 @@
+<template>
+  <div id="welcome_pulsar">
+    <div>
+      <img src="../../../assets/images/logo.svg" />
+      <h1 id="welcome_pulsar_title">PULSAR</h1>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+#welcome_pulsar {
+  width: 430px;
+  height: 33vh;
+  display: flex;
+  justify-content: center;
+  text-align: center;
+  align-items: end;
+}
+#welcome_pulsar_title {
+  margin-top: 1rem;
+  padding-right: 1.5rem;
+  font-size: 4rem;
+}
+img {
+  width: 50%;
+}
+</style>
+
+<script>
+export default {
+  name: 'WelcomePulsar',
+  components: {},
+  created() {
+    //axios
+  },
+};
+</script>


### PR DESCRIPTION
로그인 기능을 프론트에서 테스트해볼 수 있습니다.
npm run serve한 후 로그인을 시도해 보세요 (db에 데이터 넣고 시도해야 함)
정상적으로 되었다면 /routines로 리다이렉트되고, 성공 alert창이 나와야 합니다.

이외에도 정상적인 화면이 (드디어) 구현되었고, 그에 따른 css 수정이 있습니다.
인풋 태그가 아닌 컴포넌트에서 v-model로 양방향 바인딩하는 원리도 잘 깨달을 수 있었습니다.
이제 진짜로 속도가 날 것 같습니다.