### PR TITLE
feat: signup view 구현

### DIFF
--- a/client/src/module/common/SquareButton.vue
+++ b/client/src/module/common/SquareButton.vue
@@ -28,7 +28,6 @@ button {
   border-radius: 8px;
   color: var(--text);
   width: calc(100% - 3rem);
-  margin-bottom: 1rem;
   font-size: 0.9rem;
   font-family: 'bd', sans-serif;
 }

--- a/client/src/module/common/TagForm.vue
+++ b/client/src/module/common/TagForm.vue
@@ -1,0 +1,91 @@
+<template>
+  <div class="tagform" :style="styles">
+    <!--전체 태그를 불러올 때-->
+    <div v-if="tags.length > 0">
+      <TagItem
+        v-for="({ tagNo, tagName } = tag, idx) in tags"
+        :key="idx"
+        :tagNo="tagNo"
+        :tagName="tagName"
+        :selectable="selectable"
+        :selectedTag="selectedTag"
+      />
+    </div>
+    <!--선택된 태그를 불러올 때-->
+    <div v-else>
+      <TagItem
+        v-for="({ tagNo, tagName } = tag, idx) in selectedTag"
+        :key="idx"
+        :tagNo="tagNo"
+        :tagName="tagName"
+        :selectable="selectable"
+        :selectedTag="selectedTag"
+      />
+    </div>
+  </div>
+</template>
+
+<script>
+import TagItem from './TagItem.vue';
+
+export default {
+  name: 'TagForm',
+  props: {
+    tags: Array,
+    selectable: Boolean,
+    selectedTag: Array,
+  },
+
+  components: { TagItem },
+  computed: {
+    isValid() {
+      const regex =
+        /^(?=.*[a-z])(?=.*\d)(?=.*[@$!%*#?&])[a-z\d@$!%*#?&]{8,}$/i;
+      return regex.test(this.value);
+    },
+    styles() {
+      return {
+        '--margin': this.margin,
+        '--display': this.caption ? 'block' : 'none',
+        '--caption-color':
+          //중첩 삼항연산자입니다. inputType이 password이고 비밀번호가 valid하다면...
+          this.inputType === 'password'
+            ? this.isValid
+              ? '#09DF78'
+              : '#DF093D'
+            : '#666666',
+      };
+    },
+  },
+};
+</script>
+
+<style scoped>
+@import url('../../assets/css/init.css');
+@import url('../../assets/css/root.css');
+@import url('../../assets/css/typography.css');
+.text_input_container {
+  margin-bottom: var(--margin);
+}
+input[type='text'],
+input[type='email'],
+input[type='password'] {
+  padding: 0.75rem;
+  border: 1px solid var(--light-color-black);
+  border-radius: 6px;
+  outline: none;
+  font-size: 0.9rem;
+  width: calc(100% - 2rem);
+}
+
+input::placeholder {
+  color: var(--light-color-grey);
+}
+.caption {
+  color: var(--caption-color);
+  text-align: right;
+  font-size: 0.85rem;
+  padding: 0.5rem 0 0.5rem 0;
+  display: var(--display);
+}
+</style>

--- a/client/src/module/common/TextInput.vue
+++ b/client/src/module/common/TextInput.vue
@@ -9,7 +9,7 @@
         :type="inputType"
         :placeholder="placeholder"
         :value="value"
-        @change="$emit('input', $event.target.value)"
+        @keyup="$emit('input', $event.target.value)"
       />
       <p class="caption">{{ caption }}</p>
     </div>
@@ -31,10 +31,22 @@ export default {
     margin: String,
   },
   computed: {
+    isValid() {
+      const regex =
+        /^(?=.*[a-z])(?=.*\d)(?=.*[@$!%*#?&])[a-z\d@$!%*#?&]{8,}$/i;
+      return regex.test(this.value);
+    },
     styles() {
       return {
         '--margin': this.margin,
         '--display': this.caption ? 'block' : 'none',
+        '--caption-color':
+          //중첩 삼항연산자입니다. inputType이 password이고 비밀번호가 valid하다면...
+          this.inputType === 'password'
+            ? this.isValid
+              ? '#09DF78'
+              : '#DF093D'
+            : '#666666',
       };
     },
   },
@@ -63,7 +75,7 @@ input::placeholder {
   color: var(--light-color-grey);
 }
 .caption {
-  color: var(--light-color-darkgrey);
+  color: var(--caption-color);
   text-align: right;
   font-size: 0.85rem;
   padding: 0.5rem 0 0.5rem 0;

--- a/client/src/module/landing/components/LoginContainer.vue
+++ b/client/src/module/landing/components/LoginContainer.vue
@@ -22,7 +22,13 @@ export default {
             this.$store.dispatch('login', res.data);
             //기본 화면인 루틴으로 리다이렉트시킵니다.
             this.$router.push('/routines');
-          } else console.log('로그인에 실패했어요');
+          } else if (res && res.status < 500)
+            alert(
+              '로그인에 실패했어요. 아이디와 비밀번호를 확인해 주세요.'
+            );
+          else {
+            alert('서버가 아파요. 최대한 빠르게 치료할게요.');
+          }
         })
         .catch((err) => err.status);
     },

--- a/client/src/module/landing/components/LoginContent.vue
+++ b/client/src/module/landing/components/LoginContent.vue
@@ -3,31 +3,33 @@
     <!-- 상위 컴포넌트에서 v-model은 하위 컴포넌트에서 emit해 바인딩할 수 있습니다.
          v-model이 하위 컴포넌트에서의 emit + 그 하위 컴포넌트로 pass prop인 것을 이용한 것입니다. -->
     <h2>PULSAR에 오신 것을 환영합니다!</h2>
-    <p class="login_content_caption">
+    <p id="login_content_caption">
       서비스를 이용하려면 로그인해야 합니다.
     </p>
-    <text-input
-      :input-name="'Email'"
-      :placeholder="'Email'"
-      :type="'email'"
-      :margin="'1rem'"
-      v-model="email"
-    />
-    <text-input
-      :input-name="'Password'"
-      :placeholder="'Password'"
-      :type="'password'"
-      :margin="'1rem'"
-      :caption="'영문 소문자, 숫자, 특수문자 포함 8자리 이상'"
-      v-model="password"
-    />
-    <square-button
-      :theme="'highlight'"
-      :value="'LOGIN'"
-      @handle-click="handleClick"
-    />
+    <form @keyup.enter="handleBtn">
+      <text-input
+        :input-name="'Email'"
+        :placeholder="'Email'"
+        :inputType="'email'"
+        :margin="'1rem'"
+        v-model="email"
+      />
+      <text-input
+        :input-name="'Password'"
+        :placeholder="'Password'"
+        :inputType="'password'"
+        :margin="'3rem'"
+        v-model="password"
+      />
+      <square-button
+        :theme="'highlight'"
+        :value="'LOGIN'"
+        @handle-click="handleBtn"
+        id="login_content_loginBtn"
+      />
+    </form>
     <router-link to="/signup">
-      <square-button :theme="'white'" :value="'SIGN UP'" />
+      <square-button :theme="'white'" :value="'아직 회원이 아니에요'" />
     </router-link>
   </div>
 </template>
@@ -40,8 +42,11 @@
 #login_content {
   padding: 1.5rem;
 }
-.login_content_caption {
+#login_content_caption {
   margin: 1rem 0 2rem 0;
+}
+#login_content_loginBtn {
+  margin-bottom: 1rem;
 }
 </style>
 
@@ -60,7 +65,7 @@ export default {
     };
   },
   methods: {
-    handleClick() {
+    handleBtn() {
       //로그인을 시도하기 위해 위쪽으로 로그인 이벤트와 값을 보내고,
       //양방향 바인딩되어 있는 데이터 쪽의 값을 초기화해 인풋을 빈 값으로 만듭니다.
       this.$emit('login', this.email, this.password);

--- a/client/src/module/landing/components/SignupContainer.vue
+++ b/client/src/module/landing/components/SignupContainer.vue
@@ -1,0 +1,42 @@
+<template>
+  <div id="signup_container">
+    <signup-content @signup="signup" />
+  </div>
+</template>
+
+<script>
+import SignupContent from './SignupContent.vue';
+import { postMemberSignUp } from '../../../core/api/member';
+
+export default {
+  name: 'SignupContainer',
+  components: { SignupContent },
+  methods: {
+    signup(email, password, nickname, selectedTag, profileImg) {
+      const data = {
+        email,
+        password,
+        nickname,
+        selectedTag,
+        profileImg,
+      };
+      postMemberSignUp(data)
+        .then((res) => {
+          if (res.status === 201) {
+            console.log('회원가입이 잘 되었어요');
+            this.$router.push('/');
+          }
+        })
+        .catch((err) => {
+          console.log('회원가입에 실패했어요');
+        });
+    },
+  },
+};
+</script>
+
+<style scoped>
+@import url('../../../assets/css/init.css');
+@import url('../../../assets/css/root.css');
+@import url('../../../assets/css/typography.css');
+</style>

--- a/client/src/module/landing/components/SignupContent.vue
+++ b/client/src/module/landing/components/SignupContent.vue
@@ -1,0 +1,106 @@
+<template>
+  <div id="signup_content">
+    <!-- 상위 컴포넌트에서 v-model은 하위 컴포넌트에서 emit해 바인딩할 수 있습니다.
+         v-model이 하위 컴포넌트에서의 emit + 그 하위 컴포넌트로 pass prop인 것을 이용한 것입니다. -->
+    <h2>PULSAR의 멤버가 되세요!</h2>
+    <p id="signup_content_caption">
+      멤버로 가입하시면 모든 서비스를 이용하실 수 있습니다.
+    </p>
+    <form @keyup.enter="handleBtn">
+      <text-input
+        :input-name="'Email'"
+        :placeholder="'Email'"
+        :inputType="'email'"
+        :margin="'1rem'"
+        v-model="email"
+      />
+      <text-input
+        :input-name="'Password'"
+        :placeholder="'Password'"
+        :inputType="'password'"
+        :caption="'영문 소문자, 숫자, 특수문자 포함 8자리 이상'"
+        v-model="password"
+      />
+      <text-input
+        :input-name="'Nickname'"
+        :placeholder="'Nickname'"
+        :inputType="'text'"
+        :margin="'1rem'"
+        v-model="nickname"
+      />
+      <!--tag components-->
+      <text-input
+        :input-name="'selectedTag'"
+        :placeholder="'주된 관심사'"
+        :type="'text'"
+        :margin="'3rem'"
+        v-model="selectedTag"
+      />
+      <square-button
+        :theme="'highlight'"
+        :value="'SIGN UP'"
+        @handle-click="handleBtn"
+        id="signup_content_signupBtn"
+      />
+    </form>
+    <router-link to="/">
+      <square-button :theme="'white'" :value="'이미 아이디가 있어요'" />
+    </router-link>
+  </div>
+</template>
+
+<style scoped>
+@import url('../../../assets/css/init.css');
+@import url('../../../assets/css/root.css');
+@import url('../../../assets/css/typography.css');
+
+#signup_content {
+  padding: 1.5rem;
+}
+#signup_content_caption {
+  margin: 1rem 0 2rem 0;
+}
+#signup_content_signupBtn {
+  margin-bottom: 1rem;
+}
+</style>
+
+<script>
+import SquareButton from '../../common/SquareButton.vue';
+import TextInput from '../../common/TextInput.vue';
+
+export default {
+  name: 'SignupContent',
+  components: { TextInput, SquareButton },
+  data() {
+    return {
+      //각 커스텀 인풋 컴포넌트에서 받은 입력값을 v-model로 양방향 바인딩합니다.
+      email: '',
+      password: '',
+      nickname: '',
+      selectedTag: '',
+      profileImg: '',
+    };
+  },
+  methods: {
+    handleBtn() {
+      //로그인을 시도하기 위해 위쪽으로 로그인 이벤트와 값을 보내고,
+      //양방향 바인딩되어 있는 데이터 쪽의 값을 초기화해 인풋을 빈 값으로 만듭니다.
+
+      this.$emit(
+        'signup',
+        this.email,
+        this.password,
+        this.nickname,
+        this.selectedTag,
+        this.profileImg
+      );
+      this.email = '';
+      this.password = '';
+      this.nickname = '';
+      this.selectedTag = [];
+      this.profileImg = null;
+    },
+  },
+};
+</script>

--- a/client/src/module/landing/router/landing.js
+++ b/client/src/module/landing/router/landing.js
@@ -1,6 +1,6 @@
 import LandingView from '../LandingView.vue';
 import LoginContainer from '../components/LoginContainer.vue';
-import SignUp from '../components/SignUp.vue';
+import SignupContainer from '../components/SignupContainer.vue';
 
 export default [
   {
@@ -10,7 +10,7 @@ export default [
       { path: '', component: LoginContainer },
       {
         path: 'signup', //회원가입 폼
-        component: SignUp,
+        component: SignupContainer,
       },
     ],
   },


### PR DESCRIPTION
- 태그 폼 컴포넌트를 구현했습니다. (임시)
- signup 컴포넌트를 content와 container로 분리하고, 그에 따라 라우터를 재설정했습니다.
- Input type이 password면 비밀번호 검사 기능이 작동합니다. 영문 소문자, 숫자, 특수문자를 모두 포함해야 하고 8자를 넘어야 합니다.