### PR TITLE
feat: 루틴 API 응답 수정

### DIFF
--- a/server/pulsar/src/main/java/com/hammer/pulsar/controller/RoutineRestController.java
+++ b/server/pulsar/src/main/java/com/hammer/pulsar/controller/RoutineRestController.java
@@ -54,8 +54,10 @@ public class RoutineRestController {
 
     // 루틴 상세보기 요청 API
     @GetMapping("/routine/{routineId}")
-    public ResponseEntity<Routine> showRoutine(@PathVariable int routineId) {
-        Routine routine = routineService.getRoutineDetail(routineId);
+    public ResponseEntity<Routine> showRoutine(@PathVariable int routineId, HttpServletRequest request) {
+        int memberId = UUIDTokenManager.getLoginUserInfo(request.getHeader("Authorization")).getMemberNo();
+
+        Routine routine = routineService.getRoutineDetail(routineId, memberId);
 
         return new ResponseEntity<>(routine, HttpStatus.OK);
     }

--- a/server/pulsar/src/main/java/com/hammer/pulsar/controller/RoutineRestController.java
+++ b/server/pulsar/src/main/java/com/hammer/pulsar/controller/RoutineRestController.java
@@ -75,9 +75,11 @@ public class RoutineRestController {
 
     // 루틴 수정 API
     @PutMapping("/routine/{routineId}")
-    public ResponseEntity<Void> modifyRoutineInfo(@PathVariable int routineId, RoutineModifyForm form) {
+    public ResponseEntity<Void> modifyRoutineInfo(@PathVariable int routineId, RoutineModifyForm form, HttpServletRequest request) {
+        int memberId = UUIDTokenManager.getLoginUserInfo(request.getHeader("Authorization")).getMemberNo();
+
         form.setRoutineId(routineId);
-        routineService.modifyRoutineInfo(form);
+        routineService.modifyRoutineInfo(form, memberId);
 
         return new ResponseEntity<>(HttpStatus.OK);
     }

--- a/server/pulsar/src/main/java/com/hammer/pulsar/controller/RoutineRestController.java
+++ b/server/pulsar/src/main/java/com/hammer/pulsar/controller/RoutineRestController.java
@@ -86,8 +86,10 @@ public class RoutineRestController {
 
     // 루틴 삭제 API
     @DeleteMapping("/routine/{routineId}")
-    public ResponseEntity<Void> removeRoutine(@PathVariable int routineId) {
-        routineService.removeRoutine(routineId);
+    public ResponseEntity<Void> removeRoutine(@PathVariable int routineId, HttpServletRequest request) {
+        int memberId = UUIDTokenManager.getLoginUserInfo(request.getHeader("Authorization")).getMemberNo();
+
+        routineService.removeRoutine(routineId, memberId);
 
         return new ResponseEntity<>(HttpStatus.OK);
     }

--- a/server/pulsar/src/main/java/com/hammer/pulsar/dao/DayDao.java
+++ b/server/pulsar/src/main/java/com/hammer/pulsar/dao/DayDao.java
@@ -1,0 +1,16 @@
+package com.hammer.pulsar.dao;
+
+import com.hammer.pulsar.dto.routine.DayUpdateRequest;
+import com.hammer.pulsar.dto.routine.RoutineDay;
+
+// 루틴의 요일정보를 저장하는 Day 테이블과 통신하는 DAO
+public interface DayDao {
+    // 루틴의 요일정보를 추가하는 메서드
+    public int insertRoutineDay(DayUpdateRequest request);
+
+    // 루틴의 요일정보를 조회하는 메서드
+    public RoutineDay selectRoutineDay(int routineId);
+
+    // 루틴의 요일정보를 수정하는 메서드
+    public int updateRoutineDay(DayUpdateRequest request);
+}

--- a/server/pulsar/src/main/java/com/hammer/pulsar/dto/routine/DayUpdateRequest.java
+++ b/server/pulsar/src/main/java/com/hammer/pulsar/dto/routine/DayUpdateRequest.java
@@ -1,0 +1,96 @@
+package com.hammer.pulsar.dto.routine;
+
+public class DayUpdateRequest {
+    private int routineId;
+    private boolean mon;
+    private boolean tue;
+    private boolean wed;
+    private boolean thu;
+    private boolean fri;
+    private boolean sat;
+    private boolean sun;
+
+    // 기본 생성자
+    public DayUpdateRequest() {}
+
+    // Getters, Setters
+    public int getRoutineId() {
+        return routineId;
+    }
+
+    public void setRoutineId(int routineId) {
+        this.routineId = routineId;
+    }
+
+    public boolean isMon() {
+        return mon;
+    }
+
+    public void setMon(boolean mon) {
+        this.mon = mon;
+    }
+
+    public boolean isTue() {
+        return tue;
+    }
+
+    public void setTue(boolean tue) {
+        this.tue = tue;
+    }
+
+    public boolean isWed() {
+        return wed;
+    }
+
+    public void setWed(boolean wed) {
+        this.wed = wed;
+    }
+
+    public boolean isThu() {
+        return thu;
+    }
+
+    public void setThu(boolean thu) {
+        this.thu = thu;
+    }
+
+    public boolean isFri() {
+        return fri;
+    }
+
+    public void setFri(boolean fri) {
+        this.fri = fri;
+    }
+
+    public boolean isSat() {
+        return sat;
+    }
+
+    public void setSat(boolean sat) {
+        this.sat = sat;
+    }
+
+    public boolean isSun() {
+        return sun;
+    }
+
+    public void setSun(boolean sun) {
+        this.sun = sun;
+    }
+
+    // toString
+    @Override
+    public String toString() {
+        return "DayUpdateRequest{" +
+                "routineId=" + routineId +
+                ", mon=" + mon +
+                ", tue=" + tue +
+                ", wed=" + wed +
+                ", thu=" + thu +
+                ", fri=" + fri +
+                ", sat=" + sat +
+                ", sun=" + sun +
+                '}';
+    }
+    
+}

--- a/server/pulsar/src/main/java/com/hammer/pulsar/dto/routine/DayUpdateRequest.java
+++ b/server/pulsar/src/main/java/com/hammer/pulsar/dto/routine/DayUpdateRequest.java
@@ -1,5 +1,6 @@
 package com.hammer.pulsar.dto.routine;
 
+// 루틴의 요일정보 추가, 수정을 위한 DTO 클래스
 public class DayUpdateRequest {
     private int routineId;
     private boolean mon;
@@ -92,5 +93,5 @@ public class DayUpdateRequest {
                 ", sun=" + sun +
                 '}';
     }
-    
+
 }

--- a/server/pulsar/src/main/java/com/hammer/pulsar/dto/routine/Routine.java
+++ b/server/pulsar/src/main/java/com/hammer/pulsar/dto/routine/Routine.java
@@ -5,6 +5,8 @@ import java.util.List;
 // 루틴 정보를 담고 있는 DTO 클래스
 // 루틴 API에서 주고받을 정보
 public class Routine {
+    // 루틴 작성자 번호
+    private int memberNo;
     // 루틴 번호
     private int routineNo;
     // 루틴 이름
@@ -18,6 +20,14 @@ public class Routine {
     public Routine() {}
 
     // Getters, Setters
+    public int getMemberNo() {
+        return memberNo;
+    }
+
+    public void setMemberNo(int memberNo) {
+        this.memberNo = memberNo;
+    }
+
     public int getRoutineNo() {
         return routineNo;
     }
@@ -54,8 +64,9 @@ public class Routine {
     @Override
     public String toString() {
         return "Routine{" +
-                "routineNo=" + routineNo +
-                ", routineTitle=" + routineTitle +
+                "memberNo=" + memberNo +
+                ", routineNo=" + routineNo +
+                ", routineTitle='" + routineTitle + '\'' +
                 ", time=" + time +
                 ", exerciseList=" + exerciseList +
                 '}';

--- a/server/pulsar/src/main/java/com/hammer/pulsar/dto/routine/RoutineDay.java
+++ b/server/pulsar/src/main/java/com/hammer/pulsar/dto/routine/RoutineDay.java
@@ -1,0 +1,87 @@
+package com.hammer.pulsar.dto.routine;
+
+// 루틴의 요일정보를 담고 있는 DTO 클래스
+public class RoutineDay {
+    private boolean mon;
+    private boolean tue;
+    private boolean wed;
+    private boolean thu;
+    private boolean fri;
+    private boolean sat;
+    private boolean sun;
+
+    // 기본 생성자
+    public RoutineDay() {}
+
+    // Getters, Setters
+    public boolean isMon() {
+        return mon;
+    }
+
+    public void setMon(boolean mon) {
+        this.mon = mon;
+    }
+
+    public boolean isTue() {
+        return tue;
+    }
+
+    public void setTue(boolean tue) {
+        this.tue = tue;
+    }
+
+    public boolean isWed() {
+        return wed;
+    }
+
+    public void setWed(boolean wed) {
+        this.wed = wed;
+    }
+
+    public boolean isThu() {
+        return thu;
+    }
+
+    public void setThu(boolean thu) {
+        this.thu = thu;
+    }
+
+    public boolean isFri() {
+        return fri;
+    }
+
+    public void setFri(boolean fri) {
+        this.fri = fri;
+    }
+
+    public boolean isSat() {
+        return sat;
+    }
+
+    public void setSat(boolean sat) {
+        this.sat = sat;
+    }
+
+    public boolean isSun() {
+        return sun;
+    }
+
+    public void setSun(boolean sun) {
+        this.sun = sun;
+    }
+
+    // toString
+    @Override
+    public String toString() {
+        return "RoutineDay{" +
+                "mon=" + mon +
+                ", tue=" + tue +
+                ", wed=" + wed +
+                ", thu=" + thu +
+                ", fri=" + fri +
+                ", sat=" + sat +
+                ", sun=" + sun +
+                '}';
+    }
+
+}

--- a/server/pulsar/src/main/java/com/hammer/pulsar/dto/routine/RoutineModifyRequest.java
+++ b/server/pulsar/src/main/java/com/hammer/pulsar/dto/routine/RoutineModifyRequest.java
@@ -11,7 +11,7 @@ public class RoutineModifyRequest {
     // 루틴 반복 주기
     private int repeatPeriod;
     // 루틴 요일
-    private List<String> repeatDay;
+    private RoutineDay repeatDay;
     // 루틴 시작 시간
     private int startHour;
     // 루틴 시작 분
@@ -56,11 +56,11 @@ public class RoutineModifyRequest {
         this.repeatPeriod = repeatPeriod;
     }
 
-    public List<String> getRepeatDay() {
+    public RoutineDay getRepeatDay() {
         return repeatDay;
     }
 
-    public void setRepeatDay(List<String> repeatDay) {
+    public void setRepeatDay(RoutineDay repeatDay) {
         this.repeatDay = repeatDay;
     }
 

--- a/server/pulsar/src/main/java/com/hammer/pulsar/dto/routine/RoutineRegistRequest.java
+++ b/server/pulsar/src/main/java/com/hammer/pulsar/dto/routine/RoutineRegistRequest.java
@@ -13,7 +13,7 @@ public class RoutineRegistRequest {
     // 루틴 반복 주기
     private int repeatPeriod;
     // 루틴 요일
-    private List<String> repeatDay;
+    private RoutineDay repeatDay;
     // 루틴 시작 시간
     private int startHour;
     // 루틴 시작 분
@@ -65,11 +65,11 @@ public class RoutineRegistRequest {
         this.repeatPeriod = repeatPeriod;
     }
 
-    public List<String> getRepeatDay() {
+    public RoutineDay getRepeatDay() {
         return repeatDay;
     }
 
-    public void setRepeatDay(List<String> repeatDay) {
+    public void setRepeatDay(RoutineDay repeatDay) {
         this.repeatDay = repeatDay;
     }
 

--- a/server/pulsar/src/main/java/com/hammer/pulsar/dto/routine/RoutineTime.java
+++ b/server/pulsar/src/main/java/com/hammer/pulsar/dto/routine/RoutineTime.java
@@ -1,7 +1,5 @@
 package com.hammer.pulsar.dto.routine;
 
-import java.util.List;
-
 // 루틴의 시간 정보를 저장하고 있는 DTO 클래스
 public class RoutineTime {
     // 시간 정보
@@ -10,7 +8,7 @@ public class RoutineTime {
     // 반복 단위 (day, week, month)
     private String repeatUnit;
     // 요일 (mon, tue, wed, thu, fri, sat, sun)
-    private List<String> repeatDay;
+    private RoutineDay repeatDay;
     // 시작 시간 : 시(24시), 분
     private int startHour;
     private int startMin;
@@ -35,11 +33,11 @@ public class RoutineTime {
         this.repeatUnit = repeatUnit;
     }
 
-    public List<String> getRepeatDay() {
+    public RoutineDay getRepeatDay() {
         return repeatDay;
     }
 
-    public void setRepeatDay(List<String> repeatDay) {
+    public void setRepeatDay(RoutineDay repeatDay) {
         this.repeatDay = repeatDay;
     }
 

--- a/server/pulsar/src/main/java/com/hammer/pulsar/service/RoutineService.java
+++ b/server/pulsar/src/main/java/com/hammer/pulsar/service/RoutineService.java
@@ -22,7 +22,7 @@ public interface RoutineService {
     public Routine getRoutineDetail(int routineId, int memberId);
 
     // 선택한 루틴을 수정하는 로직
-    public void modifyRoutineInfo(RoutineModifyForm form);
+    public void modifyRoutineInfo(RoutineModifyForm form, int memberId);
 
     // 선택한 루틴을 삭제하는 로직
     public void removeRoutine(int routineId);

--- a/server/pulsar/src/main/java/com/hammer/pulsar/service/RoutineService.java
+++ b/server/pulsar/src/main/java/com/hammer/pulsar/service/RoutineService.java
@@ -19,7 +19,7 @@ public interface RoutineService {
     public List<Routine> getAllRoutines(int memberId);
 
     // 선택한 루틴을 상세조회 하는 로직
-    public Routine getRoutineDetail(int routineId);
+    public Routine getRoutineDetail(int routineId, int memberId);
 
     // 선택한 루틴을 수정하는 로직
     public void modifyRoutineInfo(RoutineModifyForm form);

--- a/server/pulsar/src/main/java/com/hammer/pulsar/service/RoutineService.java
+++ b/server/pulsar/src/main/java/com/hammer/pulsar/service/RoutineService.java
@@ -25,6 +25,6 @@ public interface RoutineService {
     public void modifyRoutineInfo(RoutineModifyForm form, int memberId);
 
     // 선택한 루틴을 삭제하는 로직
-    public void removeRoutine(int routineId);
+    public void removeRoutine(int routineId, int memberId);
 
 }

--- a/server/pulsar/src/main/java/com/hammer/pulsar/service/RoutineServiceImpl.java
+++ b/server/pulsar/src/main/java/com/hammer/pulsar/service/RoutineServiceImpl.java
@@ -88,12 +88,16 @@ public class RoutineServiceImpl implements RoutineService {
 
     /**
      * 선택한 루틴 정보를 수정하는 메서드
+     * 만약 루틴의 작성자와 수정 요청한 memberId가 다르면 401 UNAUTHORIZED
      *
      * @param routine
      */
     @Override
-    public void modifyRoutineInfo(RoutineModifyForm form) {
-        
+    public void modifyRoutineInfo(RoutineModifyForm form, int memberId) {
+        if(routineDao.selectRoutineByRoutineId(form.getRoutineId()).getMemberNo() != memberId) {
+            throw new UnauthorizedException();
+        }
+
         routineDao.updateRoutine(new RoutineModifyRequest(form));
     }
 

--- a/server/pulsar/src/main/java/com/hammer/pulsar/service/RoutineServiceImpl.java
+++ b/server/pulsar/src/main/java/com/hammer/pulsar/service/RoutineServiceImpl.java
@@ -103,11 +103,16 @@ public class RoutineServiceImpl implements RoutineService {
 
     /**
      * 선택한 루틴을 삭제하는 메서드
+     * 만약 루틴의 작성자와 삭제 요청한 memberId가 다르면 401 UNAUTHORIZED
      *
      * @param routineId
      */
     @Override
-    public void removeRoutine(int routineId) {
+    public void removeRoutine(int routineId, int memberId) {
+        if(routineDao.selectRoutineByRoutineId(routineId).getMemberNo() != memberId) {
+            throw new UnauthorizedException();
+        }
+
         if(routineDao.deleteRoutine(routineId) == 0) throw new NoSuchElementException("존재하지 않는 루틴입니다.");
     }
 

--- a/server/pulsar/src/main/java/com/hammer/pulsar/service/RoutineServiceImpl.java
+++ b/server/pulsar/src/main/java/com/hammer/pulsar/service/RoutineServiceImpl.java
@@ -5,6 +5,7 @@ import com.hammer.pulsar.dao.RoutineDao;
 import com.hammer.pulsar.dao.RoutineDetailDao;
 import com.hammer.pulsar.dto.member.MemberProfile;
 import com.hammer.pulsar.dto.routine.*;
+import com.hammer.pulsar.exception.UnauthorizedException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -69,13 +70,17 @@ public class RoutineServiceImpl implements RoutineService {
 
     /**
      * 선택한 루틴의 상세 정보를 조회하는 메서드
+     * 만약 루틴의 작성자와 조회 요청한 memberId가 다르면 401 UNAUTHORIZED
      *
      * @param routineId
      * @return
      */
     @Override
-    public Routine getRoutineDetail(int routineId) {
+    public Routine getRoutineDetail(int routineId, int memberId) {
         Routine routine = routineDao.selectRoutineByRoutineId(routineId);
+
+        if(routine.getMemberNo() != memberId) throw new UnauthorizedException();
+
         routine.setExerciseList(routineDetailDao.selectExercisesByRoutineId(routine.getRoutineNo()));
 
         return routine;

--- a/server/pulsar/src/main/java/com/hammer/pulsar/service/RoutineServiceImpl.java
+++ b/server/pulsar/src/main/java/com/hammer/pulsar/service/RoutineServiceImpl.java
@@ -16,14 +16,12 @@ import java.util.NoSuchElementException;
 // 실제 로직이 구현된 RoutineService 인터페이스의 구현체 클래스
 @Service
 public class RoutineServiceImpl implements RoutineService {
-    private final MemberDao memberDao;
     private final RoutineDao routineDao;
     private final RoutineDetailDao routineDetailDao;
     private final DayDao dayDao;
 
     @Autowired
-    public RoutineServiceImpl(MemberDao memberDao, RoutineDao routineDao, RoutineDetailDao routineDetailDao, DayDao dayDao) {
-        this.memberDao = memberDao;
+    public RoutineServiceImpl(RoutineDao routineDao, RoutineDetailDao routineDetailDao, DayDao dayDao) {
         this.routineDao = routineDao;
         this.routineDetailDao = routineDetailDao;
         this.dayDao = dayDao;
@@ -84,7 +82,8 @@ public class RoutineServiceImpl implements RoutineService {
     public Routine getRoutineDetail(int routineId, int memberId) {
         Routine routine = routineDao.selectRoutineByRoutineId(routineId);
 
-        if(routine.getMemberNo() != memberId) throw new UnauthorizedException();
+        if(routine == null) throw new NoSuchElementException("존재하지 않는 루틴입니다.");
+        if(routine.getMemberNo() != memberId) throw new UnauthorizedException("권한이 없습니다.");
 
         routine.setExerciseList(routineDetailDao.selectExercisesByRoutineId(routineId));
         routine.getTime().setRepeatDay(dayDao.selectRoutineDay(routineId));
@@ -102,7 +101,7 @@ public class RoutineServiceImpl implements RoutineService {
     @Override
     public void modifyRoutineInfo(RoutineModifyForm form, int memberId) {
         if(routineDao.selectRoutineByRoutineId(form.getRoutineId()).getMemberNo() != memberId) {
-            throw new UnauthorizedException();
+            throw new UnauthorizedException("권한이 없습니다.");
         }
 
         routineDao.updateRoutine(new RoutineModifyRequest(form));
@@ -117,7 +116,7 @@ public class RoutineServiceImpl implements RoutineService {
     @Override
     public void removeRoutine(int routineId, int memberId) {
         if(routineDao.selectRoutineByRoutineId(routineId).getMemberNo() != memberId) {
-            throw new UnauthorizedException();
+            throw new UnauthorizedException("권한이 없습니다.");
         }
 
         if(routineDao.deleteRoutine(routineId) == 0) throw new NoSuchElementException("존재하지 않는 루틴입니다.");

--- a/server/pulsar/src/main/resources/mappers/dayMapper.xml
+++ b/server/pulsar/src/main/resources/mappers/dayMapper.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.hammer.pulsar.dao.DayDao">
+
+    <!--  루틴의 요일정보를 추가하는 SQL  -->
+    <insert id="insertRoutineDay" parameterType="DayUpdateRequest">
+        INSERT INTO TB_DAY
+        VALUES (#{routineId}, #{mon}, #{tue}, #{wed}, #{thu}, #{fri}, #{sat}, #{sun})
+    </insert>
+
+    <!--  루틴의 요일정보를 조회하는 SQL  -->
+    <select id="selectRoutineDay" parameterType="int" resultType="list">
+        SELECT
+            MON,
+            TUE,
+            WED,
+            THU,
+            FRI,
+            SAT,
+            SUN
+        FROM TB_DAY
+        WHERE
+            ROUTINE_ID = #{routineId}
+    </select>
+
+    <!--  루틴의 요일정보를 수정하는 SQL  -->
+    <update id="updateRoutineDay" parameterType="DayUpdateRequest">
+        UPDATE TB_DAY
+        SET
+            MON = #{mon},
+            TUE = #{tue},
+            WED = #{wed},
+            THU = #{thu},
+            FRI = #{fri},
+            SAT = #{sat},
+            SUN = #{sun}
+        WHERE
+            ROUTINE_ID = #{routineId}
+    </update>
+
+</mapper>

--- a/server/pulsar/src/main/resources/mappers/dayMapper.xml
+++ b/server/pulsar/src/main/resources/mappers/dayMapper.xml
@@ -9,7 +9,7 @@
     </insert>
 
     <!--  루틴의 요일정보를 조회하는 SQL  -->
-    <select id="selectRoutineDay" parameterType="int" resultType="list">
+    <select id="selectRoutineDay" parameterType="int" resultType="RoutineDay">
         SELECT
             MON,
             TUE,

--- a/server/pulsar/src/main/resources/mappers/routineMapper.xml
+++ b/server/pulsar/src/main/resources/mappers/routineMapper.xml
@@ -5,6 +5,7 @@
     <!--  루틴 조회 쿼리 결과 매퍼  -->
     <resultMap id="RoutineMapper" type="Routine">
         <result column="ID" property="routineNo" />
+        <result column="MEMBER_ID" property="memberNo" />
         <result column="TITLE" property="routineTitle" />
         <result column="REPEAT_UNIT" property="time.repeatUnit" />
         <result column="REPEAT_PERIOD" property="time.repeatPeriod" />
@@ -15,7 +16,7 @@
     <!--  루틴 추가를 위한 SQL  -->
     <insert id="insertRoutine" parameterType="RoutineRegistRequest">
         INSERT INTO TB_ROUTINE (MEMBER_ID, TITLE, REPEAT_UNIT, REPEAT_PERIOD, START_HOUR, START_MIN)
-        VALUES (#{writeId}, #{title}, #{repeatUnit}, #{repeatPeriod}, #{startHour}, #{startMin})
+        VALUES (#{writerId}, #{title}, #{repeatUnit}, #{repeatPeriod}, #{startHour}, #{startMin})
     </insert>
 
     <!--  루틴 목록 조회를 위한 SQL  -->

--- a/server/pulsar/src/main/resources/mappers/routineMapper.xml
+++ b/server/pulsar/src/main/resources/mappers/routineMapper.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.hammer.pulsar.dao.RoutineDao">
+
+    <!--  루틴 조회 쿼리 결과 매퍼  -->
     <resultMap id="RoutineMapper" type="Routine">
         <result column="ID" property="routineNo" />
         <result column="TITLE" property="routineTitle" />
@@ -32,11 +34,6 @@
         FROM TB_ROUTINE
         WHERE
             ID = #{routineId}
-    </select>
-
-    <!--  루틴 작성자 프로필 조회를 위한 SQL  -->
-    <select id="selectProfileByRoutineId" parameterType="int">
-
     </select>
 
     <!--  루틴 수정을 위한 SQL  -->


### PR DESCRIPTION
- 루틴 조회시 루틴의 요일정보도 같이 응답으로 반환하도록 변경
- 요일정보 응답 추가로 인한 mapper.xml, DTO 클래스 추가
- 요일정보 DTO 클래스 사용으로 인한 기존 DTO 클래스의 코드 수정
- 루틴 API에 401, 404 응답코드 추가