### PR TITLE
feat: 루틴 작성, 태그폼, 무한스크롤 구현

### DIFF
--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -11,7 +11,7 @@
   },
   "plugins": ["vue"],
   "rules": {
-    "indent": ["error", 2],
+    "indent": "off",
     "linebreak-style": ["error", "unix"],
     "quotes": "off",
     "semi": ["error", "always"],

--- a/client/src/assets/css/root.css
+++ b/client/src/assets/css/root.css
@@ -3,7 +3,7 @@
   --light-color-highlight: #db3f28;
   --light-color-white: #fafafa;
   --light-color-lightgrey: #eeeeee;
-  --light-color-grey: #cccccc;
+  --light-color-grey: #aaaaaa;
   --light-color-darkgrey: #888888;
   --light-color-black: #333333;
 }

--- a/client/src/assets/css/typography.css
+++ b/client/src/assets/css/typography.css
@@ -32,8 +32,8 @@ h2 {
 }
 h3 {
   font-family: 'nm', sans-serif;
-  font-size: 1.25rem;
-  margin: 0 0 1rem 0;
+  font-size: 1.2rem;
+  margin: 0 0 0.85rem 0;
 }
 p {
   margin: 0 0.5rem 0 0.5rem;

--- a/client/src/core/components/About/AboutBtn.vue
+++ b/client/src/core/components/About/AboutBtn.vue
@@ -42,7 +42,7 @@ export default {
   color: var(--light-color-darkgrey);
   background: white;
   cursor: pointer;
-  height: 2.75rem;
+  height: 3rem;
   width: 3rem;
   font-size: 1.25rem;
 }

--- a/client/src/core/components/About/AboutContent.vue
+++ b/client/src/core/components/About/AboutContent.vue
@@ -4,7 +4,46 @@
   <article id="about_content_container" :class="{ show: show }">
     <div id="about_content_content">
       <h1>CREDITS</h1>
-      <p>민병기, 유승윤</p>
+      <div class="credit_item">
+        <h2 class="credit_title"><strong> 제작 </strong></h2>
+        <h2>민병기 유승윤</h2>
+      </div>
+      <div class="credit_item">
+        <h2 class="credit_title"><strong> Back-end </strong></h2>
+        <h2>
+          <a href="https://github.com/bmincof">민병기</a>
+        </h2>
+      </div>
+      <div class="credit_item">
+        <h2 class="credit_title">
+          <strong> Front-end </strong>
+        </h2>
+        <h2>
+          <a href="https://github.com/s-y-yu">유승윤</a>
+        </h2>
+      </div>
+      <div class="credit_item">
+        <h2 class="credit_title"><strong> TECH STACK </strong></h2>
+        <h2>
+          Back-end<br />
+          <h3>JAVA 8</h3>
+          <h3>SPRING BOOT</h3>
+          <h3>MYSQL</h3>
+          <h3>MYBATIS</h3>
+          Front-end<br />
+          <h3>VUE</h3>
+          <h3>VUEX</h3>
+          <h3>STORYBOOK</h3>
+          Project Manage<br />
+          <h3>
+            <a
+              href="https://seung-yoon-yu.notion.site/PULSAR-API-DOCUMENT-073b3b6940a943a794ffd16b75cfba02"
+              >API DOCS</a
+            >
+          </h3>
+          <h3>GITHUB</h3>
+        </h2>
+      </div>
     </div>
   </article>
 </template>
@@ -28,7 +67,7 @@ export default {
   display: none;
   width: 100vw;
   height: 100vh;
-  background: var(--light-color-highlight);
+  background: var(--light-color-black);
   z-index: 9;
 }
 #about_content_content {
@@ -40,8 +79,37 @@ export default {
   padding-top: 2rem;
 }
 h1,
+h2,
 p {
-  opacity: 0.85;
+  opacity: 0.75;
+  margin: 0 1rem 0.5rem 1rem;
+  line-height: 1.65;
+}
+h3 {
+  margin: 0;
+  line-height: 1.65;
+}
+h1 {
+  font-size: 3.5rem;
+  text-align: center;
+}
+h2 a {
+  text-decoration: underline;
+}
+h2,
+h3 {
+  font-size: 1.2rem;
+}
+.credit_item {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+h2 {
+  width: 50%;
+}
+.credit_title {
+  text-align: right;
 }
 .show {
   display: block !important;

--- a/client/src/core/components/Nav/icons/CommunityIcon.vue
+++ b/client/src/core/components/Nav/icons/CommunityIcon.vue
@@ -36,7 +36,7 @@ export default {
   computed: {
     styles() {
       return {
-        '--active': this.active ? '#666666' : '#cccccc',
+        '--active': this.active ? '#ff8048' : '#cccccc',
       };
     },
     active() {

--- a/client/src/core/components/Nav/icons/MypageIcon.vue
+++ b/client/src/core/components/Nav/icons/MypageIcon.vue
@@ -36,7 +36,7 @@ export default {
   computed: {
     styles() {
       return {
-        '--active': this.active ? '#666666' : '#cccccc',
+        '--active': this.active ? '#ff8048' : '#cccccc',
       };
     },
     active() {

--- a/client/src/core/components/Nav/icons/RoutinesIcon.vue
+++ b/client/src/core/components/Nav/icons/RoutinesIcon.vue
@@ -43,7 +43,7 @@ export default {
   computed: {
     styles() {
       return {
-        '--active': this.active ? '#666666' : '#cccccc',
+        '--active': this.active ? '#ff8048' : '#cccccc',
       };
     },
     active() {

--- a/client/src/core/components/Nav/icons/StatisticsIcon.vue
+++ b/client/src/core/components/Nav/icons/StatisticsIcon.vue
@@ -41,7 +41,7 @@ export default {
   computed: {
     styles() {
       return {
-        '--active': this.active ? '#666666' : '#cccccc',
+        '--active': this.active ? '#ff8048' : '#cccccc',
       };
     },
     active() {

--- a/client/src/core/store/mutations.js
+++ b/client/src/core/store/mutations.js
@@ -9,7 +9,7 @@ export default {
     state.profileImg = member.profileImg;
     state.token = token;
   },
-  logout() {
+  logout(state) {
     state.authenticated = false;
     state.memberNo = null;
     state.nickname = null;

--- a/client/src/module/common/CommentList.vue
+++ b/client/src/module/common/CommentList.vue
@@ -34,7 +34,7 @@ export default {
 @import url('../../assets/css/typography.css');
 
 .comment_list_container {
-  border: 1px solid var(--light-color-lightgrey);
+  border: 1px solid var(--light-color-grey);
   border-radius: 8px;
   padding: 1rem;
   margin-top: 1rem;

--- a/client/src/module/common/CommunityList.vue
+++ b/client/src/module/common/CommunityList.vue
@@ -13,10 +13,10 @@
     </p>
     <p>
       <span class="community_list_item_recommendCnt">
-        {{ recommendCnt ? recommendCnt : '0' }} Likes /</span
+        {{ recommendCnt ? recommendCnt : '0' }} Likes</span
       >
       <span class="community_list_item_viewCnt">
-        {{ viewCnt ? viewCnt : '0' }} Views
+        / {{ viewCnt ? viewCnt : '0' }} Views
       </span>
     </p>
     <div class="community_list_item_tags">
@@ -48,9 +48,9 @@ export default {
 @import url('../../assets/css/typography.css');
 
 .community_list_item {
-  border: 1px solid var(--light-color-lightgrey);
+  border: 1px solid var(--light-color-grey);
   border-radius: 8px;
-  padding: 1rem;
+  padding: 1rem 1rem 0 1rem;
   margin-bottom: 1rem;
 }
 h3 {
@@ -68,9 +68,10 @@ h3 {
 .community_list_item_viewCnt,
 .community_list_item_recommendCnt {
   font-size: 0.85rem;
-  color: var(--light-color-darkgrey);
+  line-height: 1;
+  color: var(--light-color-grey);
 }
-.community_list_item_tags {
-  margin-top: 0.5rem;
+.community_list_item_recommendCnt {
+  color: var(--light-color-point);
 }
 </style>

--- a/client/src/module/common/ExerciseList.vue
+++ b/client/src/module/common/ExerciseList.vue
@@ -1,11 +1,12 @@
 <template>
   <div class="exercise_list_container">
     <div v-if="exercise" class="exercise_list_item">
-      <h3>
-        {{ exercise.exerciseName ? exercise.exerciseName : ' --- ' }}
-      </h3>
       <p>
+        <strong>
+          {{ exercise.exerciseName ? exercise.exerciseName : ' --- ' }}
+        </strong>
         {{ exercise.count ? exercise.count + '회' : '' }}
+        {{ exercise.count && exercise.duration ? ' / ' : '' }}
         {{ exercise.duration ? exercise.duration + '분' : '' }}
       </p>
     </div>
@@ -30,9 +31,9 @@ export default {
 @import url('../../assets/css/typography.css');
 
 .exercise_list_container {
-  border: 1px solid var(--light-color-lightgrey);
+  border: 1px solid var(--light-color-grey);
   border-radius: 8px;
-  padding: 1rem;
+  padding: 0.75rem;
   margin-bottom: 1rem;
 }
 h3 {

--- a/client/src/module/common/ModalView.vue
+++ b/client/src/module/common/ModalView.vue
@@ -4,37 +4,73 @@
     <div id="modal_container">
       <div>
         <h1 id="modal_title">{{ modalTitle }}</h1>
-        <p id="modal_caption">{{ modalCaption }}</p>
+        <p id="modal_caption"></p>
         <div id="modal_contents_container">
           <div v-if="modalType === 'routine'">
             <form>
-              <div class="modal_text_input_container">
-                <span class="modal_text_input_label">매</span>
-                <text-input
-                  :input-type="'text'"
-                  :margin="'1rem'"
-                  v-model="time.repeatPeriod"
-                />
-              </div>
-              <div>
-                <p>반복 주기</p>
-                <TagForm />
-              </div>
-              <div>
-                <p>반복 단위</p>
-                <TagForm />
-              </div>
-              <text-input
-                :input-type="'text'"
-                v-model="time.startHour"
-              />
-              시
+              <h3>루틴 이름</h3>
               <text-input
                 :input-type="'text'"
                 :margin="'1rem'"
-                v-model="time.startMin"
+                v-model="routineTitle"
+                @input="setRoutineTitle"
               />
-              분에 시작
+              <div class="input_repeat">
+                <h3>반복 주기</h3>
+                <div class="input_unit_item">
+                  <text-input
+                    :input-type="'text'"
+                    :margin="'0.5rem'"
+                    v-model="time.repeatPeriod"
+                    @input="setRepeatPeriod"
+                  />
+                  <p></p>
+                  <TagForm
+                    v-model="time.repeatUnit"
+                    :selectable="true"
+                    :tags="[
+                      { tagNo: 1, tagName: '주' },
+                      // { tagNo: 2, tagName: '주' },
+                    ]"
+                    :plural="false"
+                    @tagform="setRepeatUnit"
+                  />
+                </div>
+                <div v-if="time.repeatUnit !== '일'">
+                  <TagForm
+                    v-model="time.repeatDay"
+                    :selectable="true"
+                    :tags="[
+                      { tagNo: 1, tagName: '일' },
+                      { tagNo: 2, tagName: '월' },
+                      { tagNo: 3, tagName: '화' },
+                      { tagNo: 4, tagName: '수' },
+                      { tagNo: 5, tagName: '목' },
+                      { tagNo: 6, tagName: '금' },
+                      { tagNo: 7, tagName: '토' },
+                    ]"
+                    :plural="false"
+                    @tagform="setRepeatDay"
+                  />
+                </div>
+              </div>
+              <h3>시작 시간</h3>
+              <div class="input_unit">
+                <div class="input_unit_item">
+                  <text-input
+                    :input-type="'text'"
+                    v-model="time.startHour"
+                  />
+                  <p>시</p>
+                </div>
+                <div class="input_unit_item">
+                  <text-input
+                    :input-type="'text'"
+                    v-model="time.startMin"
+                  />
+                  <p>분</p>
+                </div>
+              </div>
               <square-button
                 class="modal_btn"
                 @handle-click="modalRoutineSubmit"
@@ -57,17 +93,23 @@
                 :plural="false"
                 @tagform="setExercise"
               />
-              <text-input
-                :input-type="'text'"
-                v-model="exercise.count"
-                :margin="'1rem'"
-              />
-              회
-              <text-input
-                :input-type="'text'"
-                v-model="exercise.duration"
-              />
-              분
+              <div class="input_unit">
+                <div class="input_unit_item">
+                  <text-input
+                    :input-type="'text'"
+                    v-model="exercise.count"
+                  />
+                  <p>회</p>
+                </div>
+                <div class="input_unit_item">
+                  <text-input
+                    :input-type="'text'"
+                    v-model="exercise.duration"
+                  />
+                  <p>분</p>
+                </div>
+              </div>
+
               <square-button
                 class="modal_btn"
                 @handle-click="modalExerciseSubmit"
@@ -90,10 +132,19 @@
             <text-input
               :input-type="'textarea'"
               :placeholder="'내용'"
-              :height="'15rem'"
+              :height="'13rem'"
               v-model="community.body.content"
             />
-            //TODO: 태그 폼 삽입
+            <div id="tagFormContainer">
+              <tag-form
+                v-model="community.tagList"
+                :selectable="true"
+                :tags="tags"
+                :caption="'글의 주제를 선택하세요.'"
+                :plural="false"
+                @tagform="setTagList"
+              />
+            </div>
             <square-button
               class="modal_btn"
               @handle-click="modalCommunitySubmit"
@@ -138,7 +189,7 @@ export default {
       display: false,
       routineTitle: '',
       time: {
-        repeatPeriod: '0',
+        repeatPeriod: '1',
         repeatUnit: '',
         repeatDay: [],
         startHour: '0',
@@ -161,7 +212,7 @@ export default {
   },
   methods: {
     modalRoutineSubmit() {
-      const data = this.time;
+      const data = { routineTitle: this.routineTitle, time: this.time };
       this.$emit('modal-routine-submit', data);
     },
     modalExerciseSubmit() {
@@ -183,6 +234,21 @@ export default {
     },
     modalClose() {
       this.$emit('modal-toggle');
+    },
+    setRoutineTitle(data) {
+      this.routineTitle = data;
+    },
+    setRepeatUnit(data) {
+      this.time.repeatUnit = data[0].tagName;
+    },
+    setRepeatPeriod(data) {
+      this.time.repeatPeriod = data;
+    },
+    setRepeatDay(data) {
+      this.time.repeatDay.push(data[0].tagName);
+    },
+    setTagList(data) {
+      this.community.tagList.push(data[0]);
     },
   },
 };
@@ -221,7 +287,23 @@ export default {
   box-shadow: 0px 0px 6px var(--light-color-black);
   z-index: 9;
 }
-
+#tagFormContainer {
+  margin-top: 1rem;
+}
+.input_repeat {
+  margin-bottom: 1rem;
+}
+.input_unit {
+  display: flex;
+}
+.input_unit p {
+  margin-left: 0.5rem;
+  margin-right: 2rem;
+}
+.input_unit_item {
+  display: flex;
+  align-items: center;
+}
 #modal_contents_container div {
   width: 100%;
 }
@@ -229,7 +311,7 @@ export default {
   margin: 0;
 }
 .modal_btn {
-  margin-top: 2rem;
+  margin-top: 0.5rem;
   margin-bottom: 1rem;
 }
 </style>

--- a/client/src/module/common/RoutineList.vue
+++ b/client/src/module/common/RoutineList.vue
@@ -9,9 +9,7 @@
       <span>
         {{
           time
-            ? time.repeatPeriod +
-              time.repeatUnit +
-              '마다 ' +
+            ? '매주 ' +
               time.repeatDay +
               '요일 ' +
               time.startHour +
@@ -95,7 +93,7 @@ export default {
 @import url('../../assets/css/typography.css');
 
 .routine_list_item {
-  border: 1px solid var(--light-color-lightgrey);
+  border: 1px solid var(--light-color-grey);
   border-radius: 8px;
   padding: 1rem;
   margin-bottom: 1rem;
@@ -105,20 +103,21 @@ h3 {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.25rem;
 }
 .routine_list_item_meta {
+  margin-left: 0;
   font-size: 0.9rem;
   color: var(--light-color-darkgrey);
 }
 .routine_list_item_exerciseList {
   margin-top: 0.5rem;
-  margin-left: 1.5rem;
+  margin-left: 1rem;
 }
 .routine_list_item_exerciseList_item {
   font-size: 0.8rem;
   margin-top: 0.25rem;
   color: var(--light-color-darkgrey);
-  list-style-type: disc;
+  list-style-type: decimal;
 }
 </style>

--- a/client/src/module/common/TagForm.vue
+++ b/client/src/module/common/TagForm.vue
@@ -9,27 +9,25 @@
     <div id="tagform">
       <div v-if="tags?.length > 0" id="tagform_list_container">
         <TagItem
-          v-for="({ tagNo, tagName } = tag, idx) in tags"
-          :key="idx"
+          v-for="{ tagNo, tagName } = tag in tags"
+          :key="tagNo"
           :tagNo="tagNo"
           :tagName="tagName"
           :selectable="selectable"
+          :selectable_selected="Boolean(selectedArr[tagNo])"
           @tag-click="selectTag"
         />
       </div>
       <!--선택된 태그를 불러올 때-->
       <div v-else id="tagform_list_container">
         <TagItem
-          v-for="({ tagNo, tagName } = tag, i) in selectedTag"
-          :key="i"
-          :idx="i"
+          v-for="{ tagNo, tagName } = tag in selectedTag"
+          :key="tagNo"
           :tagNo="tagNo"
           :tagName="tagName"
-          v-model="selectedArr[i]"
-          @tagClick="selectTag"
+          @tag-click="selectTag"
         />
       </div>
-
     </div>
   </div>
 </template>
@@ -48,49 +46,30 @@ export default {
   },
   data() {
     return {
-      selectable_selectedTag: [],
-
-      selectedArr: new Array(this.tags.length).fill(false),
+      selectableSelectedTag: [],
+      selectedArr: [],
     };
   },
   methods: {
-    selectTag(tagNo, tagName, selected, idx) {
+    selectTag(tagNo, tagName, selectable_selected) {
       if (this.selectable) {
-        if (selected) {
-          if (this.plural) {
+        if (!this.plural) {
+          //하나만 선택할 수 있을 때
+          if (selectable_selected) {
             //태그를 골랐을 때
-            this.selectable_selectedTag = [
-              ...this.selectable_selectedTag,
-              {
-                tagNo: tagNo,
-                tagName: tagName,
-              },
-            ];
-          } else {
-            //지금 고른거 말고 다른 태그 선택 해제 되어야함
-            // this.selectable_selectedTag.forEach((tag, i) => {
-            //   //지금 올라온 Idx가 아니면 false, 올라왔으면 true
-            //   if (idx === i) this.selectedArr[idx] = true;
-            //   else this.selectedArr[idx] = false;
-            // });
-            this.selectable_selectedTag = [
+            this.selectableSelectedTag = [
+              // ...this.selectableSelectedTag,
               {
                 tagNo: tagNo,
                 tagName: tagName,
               },
             ];
           }
+          this.selectedArr = [];
+          this.selectedArr[tagNo] = !this.selectedArr[tagNo];
         }
-
-        //태그를 다시 눌러 뺐을 때
-        else {
-          this.selectable_selectedTag =
-            this.selectable_selectedTag.filter(
-              (item, idx) => item.tagNo !== tagNo
-            );
-        }
+        this.$emit('tagform', this.selectableSelectedTag);
       }
-      this.$emit('tagform', this.selectable_selectedTag);
     },
   },
   components: { TagItem },

--- a/client/src/module/common/TagItem.vue
+++ b/client/src/module/common/TagItem.vue
@@ -9,13 +9,70 @@
   </button>
 </template>
 
+<script>
+export default {
+  name: 'TagItem',
+  props: {
+    selected: Array,
+    selectable: Boolean,
+    selectable_selected: Boolean,
+    tagNo: Number,
+    tagName: String,
+    idx: Number,
+  },
+  methods: {
+    handleClick(event) {
+      this.$emit(
+        'tag-click',
+        this.tagNo,
+        this.tagName,
+        !this.selectable_selected,
+        this.idx
+      );
+    },
+  },
+  computed: {
+    styles() {
+      //고를 수 없는 태그 (결과로만 보여야 하는 태그, 단순히 검색 링크로만 이동하는 역할을 함)
+      if (!this.selectable) {
+        return {
+          '--color': '#ff8048',
+          '--text-color': 'white',
+          '--border': '1px solid #ff8048',
+          '--cursor': 'default',
+        };
+      } else {
+        //고를 수 있는 태그 (결과로 보이지 않고, 글 작성이나 회원가입 시 클릭했을 때 보여야 하는 태그)
+        //그 중 아직 체크되지 않은 경우
+        if (!this.selectable_selected) {
+          return {
+            '--color': 'white',
+            '--text-color': '#333333',
+            '--border': '1px solid #333333',
+            '--cursor': 'pointer',
+          };
+        } else {
+          //체크된 경우
+          return {
+            '--color': '#db3f28',
+            '--text-color': 'white',
+            '--border': '1px solid #db3f28',
+            '--cursor': 'pointer',
+          };
+        }
+      }
+    },
+  },
+};
+</script>
+
 <style scoped>
 @import url('../../assets/css/init.css');
 @import url('../../assets/css/root.css');
 @import url('../../assets/css/typography.css');
 
 button {
-  cursor: pointer;
+  cursor: var(--cursor);
   padding: 0.33rem 0.75rem 0.33rem 0.75rem;
   background: var(--color);
   border: var(--border);
@@ -24,68 +81,3 @@ button {
   margin-right: 0.25rem;
 }
 </style>
-
-<script>
-export default {
-  name: 'TagItem',
-  props: {
-    selected: Array,
-    selectable: Boolean,
-    'selectable-selected': Boolean,
-    tagNo: Number,
-    tagName: String,
-    idx: Number,
-  },
-  data() {
-    return {
-      selectable_selected: false,
-    };
-  },
-  data() {
-    return {
-      selectable_selected: false,
-    };
-  },
-  methods: {
-    handleClick(event) {
-      this.selectable_selected = !this.selectable_selected;
-
-      //TODO: 여기서 emit 한번 제대로 하면 선택 상태의 양방향 바인딩 될듯
-
-        this.selectable_selected,
-        this.idx
-
-      );
-    },
-  },
-  computed: {
-    styles() {
-      //고를 수 없는 태그 (결과로만 보여야 하는 태그, 단순히 검색 링크로만 이동하는 역할을 함)
-      if (this.selectable === false) {
-        return {
-          '--color': '#ff8048',
-          '--text-color': 'white',
-          '--border': '1px solid #ff8048',
-        };
-      } else {
-        //고를 수 있는 태그 (결과로 보이지 않고, 글 작성이나 회원가입 시 클릭했을 때 보여야 하는 태그)
-        //그 중 아직 체크되지 않은 경우
-        if (this.selectable_selected === false) {
-          return {
-            '--color': 'white',
-            '--text-color': '#333333',
-            '--border': '1px solid #333333',
-          };
-        } else {
-          //체크된 경우
-          return {
-            '--color': '#db3f28',
-            '--text-color': 'white',
-            '--border': '1px solid #db3f28',
-          };
-        }
-      }
-    },
-  },
-};
-</script>

--- a/client/src/module/common/TextInput.vue
+++ b/client/src/module/common/TextInput.vue
@@ -21,7 +21,15 @@
         :type="inputType"
         :placeholder="placeholder"
         :value="value"
-        @input="$emit('input', $event.target.value)"
+        :valueNum="valueNum"
+        @input="
+          $emit(
+            'input',
+            inputType === 'number'
+              ? $event.target.valueNum
+              : $event.target.value
+          )
+        "
       />
       <p class="caption">{{ caption }}</p>
     </div>
@@ -29,6 +37,8 @@
 </template>
 
 <script>
+import { any } from 'prop-types';
+
 export default {
   name: 'TextInput',
   props: {
@@ -40,7 +50,8 @@ export default {
     height: String,
     placeholder: String,
     caption: String,
-    value: String,
+    value: any,
+    valueNum: Number,
     margin: String,
   },
   computed: {
@@ -76,7 +87,8 @@ export default {
 }
 input[type='text'],
 input[type='email'],
-input[type='password'] {
+input[type='password'],
+input[type='number'] {
   padding: 0.75rem;
   border: 1px solid var(--light-color-black);
   border-radius: 6px;
@@ -86,7 +98,7 @@ input[type='password'] {
 }
 textarea {
   padding: 0.75rem;
-  border: 1px solid var(--light-color-black);
+  border: 2px solid var(--light-color-black);
   border-radius: 6px;
   outline: none;
   font-size: 0.9rem;

--- a/client/src/module/common/icons/GoBackIcon.vue
+++ b/client/src/module/common/icons/GoBackIcon.vue
@@ -17,9 +17,9 @@ div {
   display: inline;
 }
 .item {
-  width: 1.5rem;
-  height: 1.5rem;
-  fill: var(--light-color-darkgrey);
+  width: 2.25rem;
+  height: 2.25rem;
+  fill: var(--light-color-black);
   cursor: pointer;
 }
 .item:hover {

--- a/client/src/module/community/CommunityView.vue
+++ b/client/src/module/community/CommunityView.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="community_view">
+  <div id="community_view" ref="listContainer">
     <router-view />
   </div>
 </template>
@@ -10,9 +10,22 @@ export default {
   data() {
     return {};
   },
+  mounted() {
+    this.$refs.listContainer.addEventListener(
+      'scroll',
+      this.infiniteScroll
+    );
+  },
+  beforeUnmount() {
+    this.$refs.listContainer.removeEventListener(
+      'scroll',
+      this.infiniteScroll
+    );
+  },
   methods: {
-    staticDataCall() {
-      return Promise.all([]).then((res) => res.data);
+    infiniteScroll() {
+      const target = this.$refs.listContainer;
+      console.log(target.scrollTop);
     },
   },
 };
@@ -22,14 +35,4 @@ export default {
 @import url('../../assets/css/init.css');
 @import url('../../assets/css/root.css');
 @import url('../../assets/css/typography.css');
-
-#community_view {
-  height: 100vh;
-  overflow-y: auto;
-  -ms-overflow-style: none; /* IE and Edge */
-  scrollbar-width: none; /* Firefox */
-}
-#community_view::-webkit-scrollbar {
-  display: none; /* Chrome, Safari, Opera*/
-}
 </style>

--- a/client/src/module/community/components/CommunityDetailContainer.vue
+++ b/client/src/module/community/components/CommunityDetailContainer.vue
@@ -4,7 +4,7 @@
       :article="article"
       :comment-list="commentList"
       @modal-toggle="modalToggle"
-      @handle-input="handleInput"
+      @input="handleInput"
       @comment="comment"
       @delete-article="removeArticle"
     />
@@ -57,11 +57,18 @@ export default {
         .catch((err) => console.log(err));
     },
     comment() {
-      postArticleComment(this.$route.params.articleNo, {
-        content: this.commentContent,
-      })
-        .then((res) => (this.commentList = res.data))
-        .catch((err) => console.log(err));
+      if (
+        this.commentContent === null ||
+        this.commentContent.trim().length === 0
+      ) {
+        alert('내용을 입력하세요!');
+      } else {
+        postArticleComment(this.$route.params.articleNo, {
+          content: this.commentContent,
+        })
+          .then((res) => (this.commentList = res.data))
+          .catch((err) => console.log(err));
+      }
     },
     removeArticle() {
       deleteArticle(this.$route.params.articleNo);

--- a/client/src/module/community/components/CommunityDetailContent.vue
+++ b/client/src/module/community/components/CommunityDetailContent.vue
@@ -6,22 +6,29 @@
       </router-link>
     </div>
 
-    <h1>COMMUNITY</h1>
-    <div id="detail_content_container">
-      <h3>
-        {{ article ? article?.title : '죄송합니다.' }}
-      </h3>
-      <span>
-        {{ article?.writerInfo.writerNickname }}님이
-        {{ article?.createdAt }}에 작성
-      </span>
-      <p id="content">
-        {{
-          article
-            ? article.body.content
-            : '서버로부터 정보를 가져오지 못했어요.'
-        }}
-      </p>
+    <h1>{{ article ? article?.title : '죄송합니다.' }}</h1>
+    <p id="writerInfo">
+      {{ article?.writerInfo.writerNickname }}님이
+      {{ article?.createdAt }}에 작성
+    </p>
+    <p id="content">
+      {{
+        article
+          ? article.body.content
+          : '서버로부터 정보를 가져오지 못했어요.'
+      }}
+    </p>
+
+    <div id="update">
+      <square-button
+        :value="'글 삭제하기'"
+        @handle-click="$emit('delete-article')"
+      />
+      <div id="space" />
+      <square-button
+        :value="'글 수정하기'"
+        @handle-click="$emit('update-article')"
+      />
     </div>
     <div id="detail_content_detailWrapper">
       <div id="detail_content_comment_list">
@@ -32,15 +39,16 @@
             <text-input
               :input-type="'textarea'"
               :placeholder="'댓글을 입력하세요.'"
-              @handle-input="handleInput"
+              @input="handleInput"
               :margin="'1rem'"
               :height="'5rem'"
+              v-model="commentContent"
             />
             <square-button
               :value="'댓글 작성'"
               :theme="'point'"
-              @keyup.enter="$emit('comment')"
-              @handle-click="$emit('comment')"
+              @keyup.enter="handleComment"
+              @handle-click="handleComment"
             />
           </div>
           <div id="detail_content_comment_list">
@@ -51,16 +59,10 @@
                 :comment="c"
               />
             </div>
-            <div v-else>
+            <div v-else id="alternative">
               <p>아직 댓글이 없어요.</p>
             </div>
           </div>
-        </div>
-        <div id="delete">
-          <square-button
-            :value="'글 삭제하기'"
-            @handle-click="$emit('delete-article')"
-          />
         </div>
       </div>
     </div>
@@ -84,9 +86,18 @@ export default {
     article: Object,
     commentList: Array,
   },
+  data() {
+    return {
+      commentContent: '',
+    };
+  },
   methods: {
     handleInput(data) {
-      this.$emit('handle-input', data);
+      this.$emit('input', data);
+    },
+    handleComment() {
+      this.$emit('comment');
+      this.commentContent = '';
     },
   },
 };
@@ -108,27 +119,48 @@ export default {
   padding: 1rem;
   border-radius: 8px;
 }
+
+#space {
+  margin-left: 0.5rem;
+  margin-right: 0.5rem;
+}
+#update {
+  margin-top: 8rem;
+
+  display: flex;
+}
 h3 {
   margin-bottom: 0.5rem;
 }
-span {
-  font-size: 0.8rem;
+#writerInfo {
+  margin-top: 0.5rem;
+  margin-left: 0.1rem;
+  font-size: 0.9rem;
   color: var(--light-color-darkgrey);
 }
 p {
   margin: 0;
 }
 #content {
-  margin-top: 0.5rem;
+  margin-top: 1.5rem;
   border-radius: 8px;
+  font-size: 1.1rem;
 }
 #go_back_container {
   display: flex;
   align-items: center;
 }
+#logo_container {
+  margin: 1.5rem 0 0.25rem 0;
+}
 #logo {
-  width: 2.5rem;
-  height: 2.5rem;
+  width: 2.25rem;
+  height: 2.25rem;
+}
+#alternative {
+  margin-top: 2rem;
+  text-align: center;
+  color: var(--light-color-grey);
 }
 #detail_caption {
   margin: 0 0 1rem 0;

--- a/client/src/module/community/components/CommunityListContainer.vue
+++ b/client/src/module/community/components/CommunityListContainer.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="list_container">
+  <div id="list_container" ref="listContainer">
     <CommunityListContent
       :articles="articleList"
       @modal-toggle="modalToggle"
@@ -7,7 +7,8 @@
     <modal-view
       v-if="displayModal"
       :modal-type="'community'"
-      :modal-title="'글쓰기'"
+      :tags="tags"
+      :modal-title="'글 작성하기'"
       :modal-caption="'게시판에 글을 작성합니다.'"
       @modal-community-submit="addArticles"
       @modal-toggle="modalToggle"
@@ -29,6 +30,7 @@ import {
   getArticleList,
   postArticle,
 } from '../../../core/api/community';
+import { getTag } from '../../../core/api/tag';
 
 export default {
   name: 'CommunityListContainer',
@@ -38,23 +40,47 @@ export default {
     return {
       displayModal: false,
       articleList: null,
-      // {
-      //   routineNo: 1,
-      //   routineTitle: '아침 운동',
-      //   time: {
-      //     repeatPeriod: 1, //직접입력, 0~30
-      //     repeatUnit: 'day', //day, week, month 중 하나
-      //     repeatDay: ['mon', 'tue'], //mon, tue, wed, thu, fri, sat, sun
-      //     startHour: 17, // 루틴 시작 시간, 24시 기준
-      //     startMin: 30, // 루틴 시작 분
-      //   },
-      // },
+      tags: [],
+      isLoading: false,
     };
   },
   created() {
     this.getArticles();
+    this.getTagList();
+  },
+  mounted() {
+    this.$refs.listContainer.addEventListener(
+      'scroll',
+      this.infiniteScroll
+    );
+  },
+  beforeUnmount() {
+    this.$refs.listContainer.removeEventListener(
+      'scroll',
+      this.infiniteScroll
+    );
   },
   methods: {
+    infiniteScroll() {
+      const target = this.$refs.listContainer;
+      console.log(
+        target.scrollTop + target.clientHeight >= target.scrollHeight
+      );
+      if (
+        target.scrollTop + target.clientHeight >= target.scrollHeight &&
+        !this.isLoading
+      ) {
+        this.isLoading = true;
+        getArticleList().then((res) => {
+          console.log('한무스크롤 작동!');
+          this.articleList = [...this.articleList, ...res.data];
+          this.isLoading = false;
+        });
+      }
+    },
+    getTagList() {
+      getTag().then((res) => (this.tags = res.data));
+    },
     getArticles() {
       getArticleList()
         .then((res) => {
@@ -63,11 +89,13 @@ export default {
         .catch((err) => [err]);
     },
     addArticles(data) {
-      postArticle(data, this.$store.getters.getToken)
-        .then((res) => console.log('성공'))
+      postArticle(data)
+        .then((res) => {
+          console.log('성공');
+          this.modalToggle();
+          this.getArticles();
+        })
         .catch((err) => console.log('실패'));
-      this.getArticles();
-      this.modalToggle();
     },
     modalToggle() {
       this.displayModal = !this.displayModal;
@@ -87,6 +115,16 @@ export default {
 <style scoped>
 /* 가장 아래쪽 화면도 잘 볼 수 있도록 드립니다 */
 #list_container {
+  min-height: 100vh;
   margin-bottom: 10rem;
+}
+#list_container {
+  height: 100vh;
+  overflow-y: auto;
+  -ms-overflow-style: none; /* IE and Edge */
+  scrollbar-width: none; /* Firefox */
+}
+#list_container::-webkit-scrollbar {
+  display: none; /* Chrome, Safari, Opera*/
 }
 </style>

--- a/client/src/module/community/components/CommunityListContent.vue
+++ b/client/src/module/community/components/CommunityListContent.vue
@@ -9,7 +9,7 @@
 
     <square-button
       :value="'글 작성'"
-      :theme="'black'"
+      :theme="'point'"
       @handle-click="$emit('modal-toggle')"
     />
 
@@ -48,7 +48,7 @@ import SquareButton from '../../../module/common/SquareButton.vue';
 import CommunityList from '../../../module/common/CommunityList.vue';
 
 export default {
-  name: '',
+  name: 'CommunityListContent',
   components: { CommunityList, SquareButton },
   props: {
     articles: Array,
@@ -70,7 +70,7 @@ export default {
 }
 #logo {
   width: 2.25rem;
-  height: 2.5rem;
+  height: 2.25rem;
 }
 #btn_container {
   width: 100%;

--- a/client/src/module/mypage/MypageContainer.vue
+++ b/client/src/module/mypage/MypageContainer.vue
@@ -1,0 +1,53 @@
+<template>
+  <div id="mypage_container">
+    <div id="logo_container">
+      <img id="logo" src="../../assets/images/logo.svg" alt="logo" />
+    </div>
+    <h1>Mypage</h1>
+    <p>회원정보와 활동 내역을 확인하실 수 있어요.</p>
+    <div id="mypage_category">
+      <SquareButton :value="'log out'" @handle-click="logout" />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+@import url('../../assets/css/init.css');
+@import url('../../assets/css/root.css');
+@import url('../../assets/css/typography.css');
+#mypage_container {
+  padding: 2rem;
+}
+#logo_container {
+  margin: 1.5rem 0 0.25rem 0;
+}
+#logo {
+  width: 2.25rem;
+  height: 2.25rem;
+}
+#mypage_category {
+  margin-top: 2rem;
+}
+p {
+  margin: 0;
+}
+</style>
+
+<script>
+import { postMemberLogOut } from '../../core/api/member';
+import SquareButton from '../common/SquareButton.vue';
+
+export default {
+  name: 'MypageContainer',
+  components: { SquareButton },
+  methods: {
+    logout() {
+      postMemberLogOut().then((res) => {
+        this.$store.dispatch('logout');
+        alert('로그아웃에 성공했어요.');
+        this.$router.push('/');
+      });
+    },
+  },
+};
+</script>

--- a/client/src/module/routines/components/RoutineDetailContent.vue
+++ b/client/src/module/routines/components/RoutineDetailContent.vue
@@ -7,23 +7,23 @@
     </div>
 
     <h1>
-      {{ routine ? routine?.title : '죄송합니다.' }}
+      {{ routine ? routine?.routineTitle : '죄송합니다.' }}
     </h1>
-    <p id="detail_caption">
-      {{
-        routine?.time
-          ? routine.time.repeatPeriod +
-            routine.time.repeatUnit +
-            '마다 ' +
-            routine.time.repeatDay +
-            '요일 ' +
-            routine.time.startHour +
-            '시 ' +
-            routine.time.startMin +
-            '분에 시작'
-          : '정보를 가져오는 데 실패했어요.'
-      }}
-    </p>
+    <h3 id="detail_caption">
+      <strong>
+        {{
+          routine?.time
+            ? '매주 ' +
+              routine.time.repeatDay +
+              '요일 ' +
+              routine.time.startHour +
+              '시 ' +
+              routine.time.startMin +
+              '분에 시작'
+            : '정보를 가져오는 데 실패했어요.'
+        }}
+      </strong>
+    </h3>
     <div id="detail_content_detailWrapper">
       <div id="detail_content_exercise_list">
         <div id="detail_content_exercise_list_title">
@@ -85,6 +85,9 @@ export default {
   display: flex;
   align-items: center;
 }
+#logo_container {
+  margin: 1.5rem 0 0.25rem 0;
+}
 #logo {
   width: 2.5rem;
   height: 2.5rem;
@@ -106,5 +109,10 @@ export default {
 }
 #detail_content_exercise_list_title h3 {
   margin: 0;
+}
+#delete {
+  position: absolute;
+  width: calc(100% - 3rem);
+  bottom: 4rem;
 }
 </style>

--- a/client/src/module/routines/components/RoutineListContainer.vue
+++ b/client/src/module/routines/components/RoutineListContainer.vue
@@ -59,10 +59,9 @@ export default {
     },
     addRoutine(data) {
       postRoutine(data, this.$store.getters.getToken)
-        .then((res) => console.log('성공'))
+        .then((res) => this.getRoutineList())
         .catch((err) => console.log('실패'));
-      this.getRoutineList();
-      return modalToggle();
+      return this.modalToggle();
     },
     modalToggle() {
       this.displayModal = !this.displayModal;

--- a/client/src/module/routines/components/RoutineListContent.vue
+++ b/client/src/module/routines/components/RoutineListContent.vue
@@ -5,11 +5,14 @@
     </div>
 
     <h1>ROUTINES</h1>
-    <p id="list_caption">내 운동 루틴이에요.</p>
+    <p id="list_caption">
+      {{ this.$store.getters.getLoginUser.nickname }}
+      님의 운동 루틴이에요.
+    </p>
 
     <square-button
       :value="'새 루틴 만들기'"
-      :theme="'black'"
+      :theme="'point'"
       @handle-click="$emit('modal-toggle')"
     />
 
@@ -61,7 +64,7 @@ export default {
 }
 #logo {
   width: 2.25rem;
-  height: 2.5rem;
+  height: 2.25rem;
 }
 #btn_container {
   width: 100%;

--- a/client/src/module/statistics/StatisticsView.vue
+++ b/client/src/module/statistics/StatisticsView.vue
@@ -1,0 +1,35 @@
+<template>
+  <div id="routines_view">
+    <router-view />
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'StatisticsView',
+  data() {
+    return {};
+  },
+  methods: {
+    staticDataCall() {
+      return Promise.all([]).then((res) => res.data);
+    },
+  },
+};
+</script>
+
+<style scoped>
+@import url('../../assets/css/init.css');
+@import url('../../assets/css/root.css');
+@import url('../../assets/css/typography.css');
+
+#routines_view {
+  height: 100vh;
+  overflow-y: auto;
+  -ms-overflow-style: none; /* IE and Edge */
+  scrollbar-width: none; /* Firefox */
+}
+#routines_view::-webkit-scrollbar {
+  display: none; /* Chrome, Safari, Opera*/
+}
+</style>

--- a/client/src/module/statistics/components/StatisticsContainer.vue
+++ b/client/src/module/statistics/components/StatisticsContainer.vue
@@ -1,0 +1,60 @@
+<template>
+  <div id="statistics_container">
+    <div id="logo_container">
+      <img id="logo" src="../../../assets/images/logo.svg" alt="logo" />
+    </div>
+    <h1>STATISTICS</h1>
+    <p>통계 및 업적 달성 현황을 확인하실 수 있어요.</p>
+    <div class="statistics_items">
+      <h1>기계인간</h1>
+      <p>100일 연속 루틴 성공</p>
+      <p class="achieve_date">2023. 05. 26 달성</p>
+    </div>
+    <div class="statistics_items">
+      <h1>작심삼일</h1>
+      <p>3일 연속 루틴 성공</p>
+      <p class="achieve_date">2023. 02. 01 달성</p>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+@import url('../../../assets/css/init.css');
+@import url('../../../assets/css/root.css');
+@import url('../../../assets/css/typography.css');
+#statistics_container {
+  padding: 2rem;
+}
+p {
+  margin: 0;
+}
+.statistics_items {
+  margin-top: 1rem;
+  border: 1px solid var(--light-color-grey);
+  border-radius: 8px;
+  padding: 1rem;
+}
+.statistics_items h1 {
+  font-size: 2.5rem;
+}
+.achieve_date {
+  color: var(--light-color-point);
+}
+#logo_container {
+  margin: 1.5rem 0 0.25rem 0;
+}
+#logo {
+  width: 2.25rem;
+  height: 2.25rem;
+}
+</style>
+
+<script>
+export default {
+  name: '',
+  components: {},
+  created() {
+    //axios
+  },
+};
+</script>

--- a/client/src/module/statistics/router/statistics.js
+++ b/client/src/module/statistics/router/statistics.js
@@ -1,8 +1,15 @@
 import StatisticsView from '../StatisticsView.vue';
+import StatisticsContainer from '../components/StatisticsContainer.vue';
 
 export default [
   {
     path: '/statistics',
     component: StatisticsView,
+    children: [
+      {
+        path: '',
+        component: StatisticsContainer,
+      },
+    ],
   },
 ];


### PR DESCRIPTION
- 루틴 작성 폼을 구현했습니다.
- 루틴 작성 시 운동을 추가할 때, 단위를 축소해 저장하도록 합니다 (주 단위만 가능)
- 루틴 작성 시 운동을 추가할 때, 운동을 하나만 고를 수 있도록 변경합니다 (태그폼 구현 완료)
- 게시판에서 글을 불러올 때 스크롤 위치에 따라 불러옵니다.
- 이때 throttle/debounce를 사용하지 않고 비동기 처리 로직을 이용해 과도한 요청이 가는 것을 막습니다.
- 그 외 css 디자인 수정과 구현하지 못한 페이지의 목업을 추가했습니다.